### PR TITLE
added PPM and Nunchuck as variant. unifyed variant naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 notifications:
   email: true
+  
+os: linux
 
-sudo: false
-
-matrix:
+jobs:
   fast_finish: true
   include:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 notifications:
   email: true
 
-os: linux
 sudo: false
 
-jobs:
+matrix:
   fast_finish: true
   include:
 
     - name: make (gcc-arm-none-eabi-7)
-      script: make
+      script: make -e VARIANT=VARIANT_ADC
       language: c
       addons:
         apt:
@@ -27,7 +26,7 @@ jobs:
       before_script: arm-none-eabi-gcc --version
 
     - name: make (gcc-arm-none-eabi-5)
-      script: make -e VARIANT=VARIANT_ADC
+      script: make
       language: c
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 notifications:
   email: true
 
-sudo: false
+os: linux
 
-matrix:
+jobs:
   fast_finish: true
   include:
 
@@ -49,7 +49,7 @@ matrix:
       script: platformio run
       language: python
       python:
-        - "2.7"
+      - "2.7"
       install:
       - pip install -U platformio
       - platformio update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
   include:
 
     - name: make (gcc-arm-none-eabi-7)
-      script: make
+      script: make -e VARIANT=VARIANT_ADC
       language: c
       addons:
         apt:
@@ -26,7 +26,7 @@ jobs:
       before_script: arm-none-eabi-gcc --version
 
     - name: make (gcc-arm-none-eabi-5)
-      script: make -e VARIANT_ADC
+      script: make -e VARIANT=VARIANT_ADC
       language: c
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       before_script: arm-none-eabi-gcc --version
 
     - name: platformio
-      script: platformio run -e VARIANT_ADC -e VARIANT_USART3 -e HOVERCAR -e TRANSPOTTER
+      script: platformio run -e VARIANT_ADC -e VARIANT_USART3 -e VARIANT_HOVERCAR -e VARIANT_TRANSPOTTER -e VARIANT_NUNCHUCK -e VARIANT_PPM
       language: python
       python:
         - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ matrix:
 
     - name: platformio
       script: platformio run -e VARIANT_ADC -e VARIANT_USART3 -e VARIANT_HOVERCAR -e VARIANT_TRANSPOTTER -e VARIANT_NUNCHUCK -e VARIANT_PPM
+      env: 
+        - default_envs=VARIANT_ADC
       language: python
       python:
         - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 notifications:
   email: true
-
-os: linux
+  
 sudo: false
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 notifications:
   email: true
-  
+
+os: linux
 sudo: false
 
 jobs:
@@ -8,7 +9,7 @@ jobs:
   include:
 
     - name: make (gcc-arm-none-eabi-7)
-      script: make -e VARIANT=VARIANT_ADC
+      script: make
       language: c
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,7 @@ jobs:
       before_script: arm-none-eabi-gcc --version
 
     - name: platformio
-      script: platformio run -e VARIANT_ADC -e VARIANT_USART3 -e VARIANT_HOVERCAR -e VARIANT_TRANSPOTTER -e VARIANT_NUNCHUCK -e VARIANT_PPM
-      env: 
-        - PLATFORMIO_DEFAULT_ENVS=VARIANT_ADC
+      script: platformio run
       language: python
       python:
         - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ notifications:
   email: true
 
 os: linux
+sudo: false
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
   include:
 
     - name: make (gcc-arm-none-eabi-7)
-      script: make -e VARIANT=VARIANT_ADC
+      script: make
+      env: VARIANT=VARIANT_ADC
       language: c
       addons:
         apt:
@@ -27,6 +28,7 @@ matrix:
 
     - name: make (gcc-arm-none-eabi-5)
       script: make
+      env: VARIANT=VARIANT_ADC
       language: c
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 notifications:
   email: true
-  
+
 os: linux
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       before_script: arm-none-eabi-gcc --version
 
     - name: make (gcc-arm-none-eabi-5)
-      script: make
+      script: make -e VARIANT_ADC
       language: c
       addons:
         apt:
@@ -46,7 +46,7 @@ jobs:
     - name: platformio
       script: platformio run -e VARIANT_ADC -e VARIANT_USART3 -e VARIANT_HOVERCAR -e VARIANT_TRANSPOTTER -e VARIANT_NUNCHUCK -e VARIANT_PPM
       env: 
-        - default_envs=VARIANT_ADC
+        - PLATFORMIO_DEFAULT_ENVS=VARIANT_ADC
       language: python
       python:
         - "2.7"

--- a/Inc/config.h
+++ b/Inc/config.h
@@ -145,7 +145,7 @@
 // ###### CONTROL VIA RC REMOTE ######
 // left sensor board cable. Channel 1: steering, Channel 2: speed.
 #define CONTROL_PPM                 // use PPM-Sum as input. disable CONTROL_SERIAL_USART2!
-//#define PPM_NUM_CHANNELS 6          // total number of PPM channels to receive, even if they are not used.
+#define PPM_NUM_CHANNELS 6          // total number of PPM channels to receive, even if they are not used.
 #endif 
 
 // ###### CONTROL VIA TWO POTENTIOMETERS ######
@@ -318,7 +318,7 @@
 // ############################### VALIDATE SETTINGS ###############################
 
 #if !defined(VARIANT_ADC) && !defined(VARIANT_USART3) && !defined(VARIANT_HOVERCAR) && !defined(VARIANT_TRANSPOTTER) && !defined(VARIANT_NUNCHUCK) && !defined(VARIANT_PPM)
-  #error Variant not defined! Please check platformio.ini or inc/config.h for available variants.
+  #error Variant not defined! Please check platformio.ini or Inc/config.h for available variants.
 #endif
 
 #if defined(CONTROL_SERIAL_USART2) && defined(CONTROL_SERIAL_USART3)

--- a/Inc/config.h
+++ b/Inc/config.h
@@ -3,18 +3,24 @@
 
 // ############################### DEFINE FIRMWARE VARIANT ###############################
 // For variant selection, check platformio.ini 
-// For any particular needs, feel free to change this file according to your needs.
+// or define the desired build variant here if you want to use make 
 
-// Select the VARIANT_ADC as default variant, in case NO variant is defined
-#if !defined(VARIANT_ADC) && !defined(VARIANT_USART3) && !defined(HOVERCAR) && !defined(TRANSPOTTER)
-  #define VARIANT_ADC                  
+#if !defined(PLATFORMIO)
+  //#define VARIANT_ADC         // Variant for control via ADC input
+  //#define VARIANT_USART3      // Variant for Serial control via USART3 input
+  //#define VARIANT_HOVERCAR    // Variant for HOVERCAR build
+  //#define VARIANT_TRANSPOTTER // Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
+  //#define VARIANT_NUNCHUCK    // Variant for Nunchuck controlled vehicle build
+  //#define VARIANT_PPM         // Variant for RC-Remote with PPM-Sum Signal
 #endif
+
+// For any particular needs, feel free to change this file according to your needs.
 
 // ############################### DO-NOT-TOUCH SETTINGS ###############################
 
 #define PWM_FREQ            16000     // PWM frequency in Hz
 #define DEAD_TIME              48     // PWM deadtime
-#ifdef TRANSPOTTER
+#ifdef VARIANT_TRANSPOTTER
   #define DELAY_IN_MAIN_LOOP    2
 #else
   #define DELAY_IN_MAIN_LOOP    5     // in ms. default 5. it is independent of all the timing critical stuff. do not touch if you do not know what you are doing.
@@ -92,9 +98,9 @@
 
 // ############################### SERIAL DEBUG ###############################
 
-#ifndef TRANSPOTTER
+#ifndef VARIANT_TRANSPOTTER
   //#define DEBUG_SERIAL_SERVOTERM
-  #define DEBUG_SERIAL_ASCII          // "1:345 2:1337 3:0 4:0 5:0 6:0 7:0 8:0\r\n"
+  //#define DEBUG_SERIAL_ASCII          // "1:345 2:1337 3:0 4:0 5:0 6:0 7:0 8:0\r\n"
 #endif
 
 
@@ -109,36 +115,38 @@
 #define USART3_BAUD             38400                   // UART3 baud rate (short wired cable)
 #define USART3_WORDLENGTH       UART_WORDLENGTH_8B      // UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
 
-#if defined(VARIANT_ADC) || defined(HOVERCAR)
+#if defined(VARIANT_ADC) || defined(VARIANT_HOVERCAR)
   // #define CONTROL_SERIAL_USART2                      // left sensor board cable, disable if ADC or PPM is used! For Arduino control check the hoverSerial.ino
   // #define FEEDBACK_SERIAL_USART2                     // left sensor board cable, disable if ADC or PPM is used!
   // #define DEBUG_SERIAL_USART2                        // left sensor board cable, disable if ADC or PPM is used!
 
   // #define CONTROL_SERIAL_USART3                      // right sensor board cable, disable if I2C (nunchuck or lcd) is used! For Arduino control check the hoverSerial.ino
   // #define FEEDBACK_SERIAL_USART3                     // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
-  #define DEBUG_SERIAL_USART3                           // right sensor board cable, disable if I2C (nunchuck or lcd) is used!  
+  #define DEBUG_SERIAL_USART3                        // right sensor board cable, disable if I2C (nunchuck or lcd) is used!  
 #elif defined(VARIANT_USART3)
   // #define CONTROL_SERIAL_USART2                      // left sensor board cable, disable if ADC or PPM is used! For Arduino control check the hoverSerial.ino
   // #define FEEDBACK_SERIAL_USART2                     // left sensor board cable, disable if ADC or PPM is used!
-  // #define DEBUG_SERIAL_USART2                           // left sensor board cable, disable if ADC or PPM is used!
+  // #define DEBUG_SERIAL_USART2                        // left sensor board cable, disable if ADC or PPM is used!
 
-  #define CONTROL_SERIAL_USART3                         // right sensor board cable, disable if I2C (nunchuck or lcd) is used! For Arduino control check the hoverSerial.ino
-  #define FEEDBACK_SERIAL_USART3                        // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
+  #define CONTROL_SERIAL_USART3                      // right sensor board cable, disable if I2C (nunchuck or lcd) is used! For Arduino control check the hoverSerial.ino
+  #define FEEDBACK_SERIAL_USART3                     // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
   // #define DEBUG_SERIAL_USART3                        // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
 #endif
 
 #if defined(FEEDBACK_SERIAL_USART2) || defined(DEBUG_SERIAL_USART2)
-#define UART_DMA_CHANNEL DMA1_Channel7
+  #define UART_DMA_CHANNEL DMA1_Channel7
 #endif
 
 #if defined(FEEDBACK_SERIAL_USART3) || defined(DEBUG_SERIAL_USART3)
-#define UART_DMA_CHANNEL DMA1_Channel2
+  #define UART_DMA_CHANNEL DMA1_Channel2
 #endif
 
+#ifdef VARIANT_PPM
 // ###### CONTROL VIA RC REMOTE ######
 // left sensor board cable. Channel 1: steering, Channel 2: speed.
-//#define CONTROL_PPM                 // use PPM-Sum as input. disable CONTROL_SERIAL_USART2!
+#define CONTROL_PPM                 // use PPM-Sum as input. disable CONTROL_SERIAL_USART2!
 //#define PPM_NUM_CHANNELS 6          // total number of PPM channels to receive, even if they are not used.
+#endif 
 
 // ###### CONTROL VIA TWO POTENTIOMETERS ######
 /* ADC-calibration to cover the full poti-range:
@@ -162,7 +170,7 @@
   #define ADC2_MID            2048      // mid ADC2-value while poti at minimum-position (ADC2_MIN - ADC2_MAX)
   #define ADC2_MAX            4095      // max ADC2-value while poti at maximum-position (0 - 4095)
 #endif
-#ifdef HOVERCAR
+#ifdef VARIANT_HOVERCAR
   #define CONTROL_ADC                   // use ADC as input. disable CONTROL_SERIAL_USART2, FEEDBACK_SERIAL_USART2, DEBUG_SERIAL_USART2!
   #define ADC_PROTECT_ENA               // ADC Protection Enable flag. Use this flag to make sure the ADC is protected when GND or Vcc wire is disconnected
   #define ADC_PROTECT_TIMEOUT 30        // ADC Protection: number of wrong / missing input commands before safety state is taken
@@ -173,14 +181,16 @@
   #define ADC2_MAX            2200      // max ADC2-value while poti at maximum-position (0 - 4095)
 #endif
 
-// ###### CONTROL VIA NINTENDO NUNCHUCK ######
-/* left sensor board cable.
- * keep cable short, use shielded cable, use ferrits, stabalize voltage in nunchuck,
- * use the right one of the 2 types of nunchucks, add i2c pullups.
- * use original nunchuck. most clones does not work very well.
- */
-// #define CONTROL_NUNCHUCK            // use nunchuck as input. disable FEEDBACK_SERIAL_USART3, DEBUG_SERIAL_USART3!
-
+#ifdef VARIANT_NUNCHUCK
+  // ###### CONTROL VIA NINTENDO NUNCHUCK ######
+  /* left sensor board cable.
+  * keep cable short, use shielded cable, use ferrits, stabalize voltage in nunchuck,
+  * use the right one of the 2 types of nunchucks, add i2c pullups.
+  * use original nunchuck. most clones does not work very well.
+  * Recommendation: Nunchuck Breakout Board https://github.com/Jan--Henrik/hoverboard-breakout
+  */
+  #define CONTROL_NUNCHUCK            // use nunchuck as input. disable FEEDBACK_SERIAL_USART3, DEBUG_SERIAL_USART3!
+#endif
 
 // ############################### MOTOR CONTROL #########################
 // Control selections
@@ -246,10 +256,12 @@
 #define RATE                  480   // 30.0f [-] lower value == slower rate [0, 32767] = [0.0, 2047.9375]. Do NOT make rate negative (>32767)
 
 // Value of FILTER is in fixdt(0,16,16): VAL_fixedPoint = VAL_floatingPoint * 2^16. In this case 6553 = 0.1 * 2^16
-#define FILTER                6553  // 0.1f [-] lower value == softer filter [0, 65535] = [0.0 - 1.0].
+#ifndef VARIANT_NUNCHUCK
+  #define FILTER                6553  // 0.1f [-] lower value == softer filter [0, 65535] = [0.0 - 1.0].
+#endif
 
 // ################################# DEFAULT SETTINGS ############################
-#if !defined(HOVERCAR) && !defined(TRANSPOTTER)
+#if !defined(VARIANT_HOVERCAR) && !defined(VARIANT_TRANSPOTTER) && !defined(VARIANT_NUNCHUCK)
   // Value of COEFFICIENT is in fixdt(1,16,14)
   // If VAL_floatingPoint >= 0, VAL_fixedPoint = VAL_floatingPoint * 2^14
   // If VAL_floatingPoint < 0,  VAL_fixedPoint = 2^16 + floor(VAL_floatingPoint * 2^14).
@@ -260,8 +272,8 @@
   #define INVERT_L_DIRECTION
 #endif
 
-// ################################# HOVERCAR SETTINGS ############################
-#ifdef HOVERCAR
+// ################################# VARIANT_HOVERCAR SETTINGS ############################
+#ifdef VARIANT_HOVERCAR
   #define SPEED_COEFFICIENT  16384  //  1.0f
   #define STEER_COEFFICIENT  0      //  0.0f
   
@@ -269,8 +281,8 @@
   // #define INVERT_L_DIRECTION
 #endif
 
-// ################################# TRANSPOTTER SETTINGS ############################
-#ifdef TRANSPOTTER
+// ################################# VARIANT_TRANSPOTTER SETTINGS ############################
+#ifdef VARIANT_TRANSPOTTER
   #define CONTROL_GAMETRAK
   #define SUPPORT_LCD
   #define SUPPORT_NUNCHUCK
@@ -288,18 +300,26 @@
   #define STEER_COEFFICIENT   8192   // 0.5f - higher value == stronger. if you do not want any steering, set it to 0.0; 0.0 to 1.0
 #endif
 
+// ################################# VARIANT_NUNCHUCK SETTINGS ############################
+#ifdef VARIANT_NUNCHUCK
+  // # ARMCHAIR #
+  #define FILTER             3276    //  0.05f
+  #define SPEED_COEFFICIENT  8192    //  0.5f
+  #define STEER_COEFFICIENT  62259   // -0.2f
+
+#endif
+
 // ################################# SIMPLE BOBBYCAR #################################
 // for better bobbycar code see: https://github.com/larsmm/hoverboard-firmware-hack-bbcar
 // #define FILTER             6553    //  0.1f 
 // #define SPEED_COEFFICIENT  49152   // -1.0f
 // #define STEER_COEFFICIENT  0       //  0.0f
 
-// ################################# ARMCHAIR #################################
-// #define FILTER             3276    //  0.05f
-// #define SPEED_COEFFICIENT  8192    //  0.5f
-// #define STEER_COEFFICIENT  62259   // -0.2f
-
 // ############################### VALIDATE SETTINGS ###############################
+
+#if !defined(VARIANT_ADC) && !defined(VARIANT_USART3) && !defined(VARIANT_HOVERCAR) && !defined(VARIANT_TRANSPOTTER) && !defined(VARIANT_NUNCHUCK) && !defined(VARIANT_PPM)
+  #error Variant not defined! Please check platformio.ini or inc/config.h for available variants.
+#endif
 
 #if defined(CONTROL_SERIAL_USART2) && defined(CONTROL_SERIAL_USART3)
   #error CONTROL_SERIAL_USART2 and CONTROL_SERIAL_USART3 not allowed, choose one.
@@ -349,4 +369,8 @@
 #if defined(ADC_PROTECT_ENA) && ((ADC2_MIN - ADC_PROTECT_THRESH) <= 0 || (ADC2_MAX + ADC_PROTECT_THRESH) >= 4096)
   #warning ADC2 Protection NOT possible! Adjust the ADC thresholds.
   #undef ADC_PROTECT_ENA
+#endif
+
+#if defined(CONTROL_PPM) && !defined(PPM_NUM_CHANNELS)
+  #error Total number of PPM channels needs to be set
 #endif

--- a/Inc/config.h
+++ b/Inc/config.h
@@ -8,10 +8,10 @@
 #if !defined(PLATFORMIO)
   //#define VARIANT_ADC         // Variant for control via ADC input
   //#define VARIANT_USART3      // Variant for Serial control via USART3 input
-  //#define VARIANT_HOVERCAR    // Variant for HOVERCAR build
-  //#define VARIANT_TRANSPOTTER // Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
   //#define VARIANT_NUNCHUCK    // Variant for Nunchuck controlled vehicle build
   //#define VARIANT_PPM         // Variant for RC-Remote with PPM-Sum Signal
+  //#define VARIANT_HOVERCAR    // Variant for HOVERCAR build
+  //#define VARIANT_TRANSPOTTER // Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
 #endif
 
 // For any particular needs, feel free to change this file according to your needs.

--- a/Inc/defines.h
+++ b/Inc/defines.h
@@ -174,8 +174,10 @@ void mixerFcn(int16_t rtu_speed, int16_t rtu_steer, int16_t *rty_speedR, int16_t
 void rateLimiter16(int16_t u, int16_t rate, int16_t *y);
 void multipleTapDet(int16_t u, uint32_t timeNow, MultipleTap *x);
 
-// Define I2C and Nunchuck functions
+// Define I2C, Nunchuck, PPM functions
 void I2C_Init(void);
 void Nunchuck_Init(void);
 void Nunchuck_Read(void);
 uint8_t Nunchuck_Ping(void);
+void PPM_Init(void);
+void PPM_ISR_Callback(void);

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
+# Generate dependency information
+CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
+
 # Choose variant from env var
 # make -e VARIANT=VARIANT_ADC
 
@@ -118,8 +121,6 @@ ifneq ($(VARIANT), )
 CFLAGS += -D $(VARIANT)
 endif
 
-# Generate dependency information
-CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
 
 #######################################
 # LDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ startup_stm32f103xe.s
 #######################################
 # binaries
 #######################################
-PREFIX = arm-none-eabi-
-#PREFIX = gcc-arm-none-eabi-7/bin/arm-none-eabi-
+#PREFIX = arm-none-eabi-
+PREFIX = gcc-arm-none-eabi-7/bin/arm-none-eabi-
 CC = $(PREFIX)gcc
 AS = $(PREFIX)gcc -x assembler-with-cpp
 CP = $(PREFIX)objcopy
@@ -111,10 +111,15 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
+# Choose variant from env var
+# make -e VARIANT=VARIANT_ADC
+
+ifneq ($(VARIANT), )
+CFLAGS += -D $(VARIANT)
+endif
 
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
-
 
 #######################################
 # LDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ startup_stm32f103xe.s
 #######################################
 # binaries
 #######################################
-#PREFIX = arm-none-eabi-
-PREFIX = gcc-arm-none-eabi-7/bin/arm-none-eabi-
+PREFIX = arm-none-eabi-
+#PREFIX = gcc-arm-none-eabi-7/bin/arm-none-eabi-
 CC = $(PREFIX)gcc
 AS = $(PREFIX)gcc -x assembler-with-cpp
 CP = $(PREFIX)objcopy

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ startup_stm32f103xe.s
 #######################################
 # binaries
 #######################################
-PREFIX = arm-none-eabi-
+#PREFIX = arm-none-eabi-
+PREFIX = gcc-arm-none-eabi-7/bin/arm-none-eabi-
 CC = $(PREFIX)gcc
 AS = $(PREFIX)gcc -x assembler-with-cpp
 CP = $(PREFIX)objcopy

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Most robust way for input is to use the ADC and potis. It works well even on 1m 
 ---
 ## Example variants 
 
-This firmware offers currently these variants (selectable in [platformio.ini](//platformio.ini) and / or config.h):
+This firmware offers currently these variants (selectable in [platformio.ini](platformio.ini) and / or [config.h](/Inc/config.h)):
 - **VARIANT_ADC**: In this variant the motors are controlled by two potentiometers connected to the Left sensor cable (long wired)
 - **VARIANT_USART3**: In this variant the motors are controlled via serial protocol on USART3 right sensor cable (short wired). The commands can be sent from an Arduino. Check out the [hoverserial.ino](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/tree/master/02_Arduino/hoverserial) as an example sketch.
 - **VARIANT_HOVERCAR**: In this variant the motors are controlled by two pedals brake and throttle. Reverse is engaged by double tapping on the brake pedal at standstill.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Nunchuck not working: Use the right one of the 2 types of nunchucks. Use i2c pul
 
 Nunchuck or PPM working bad: The i2c bus and PPM signal are very sensitive to emv distortions of the motor controller. They get stronger the faster you are. Keep cables short, use shielded cable, use ferrits, stabilize voltage in nunchuck or reviever, add i2c pullups. To many errors leads to very high accelerations which triggers the protection board within the battery to shut everything down.
 
+Recommendation: Nunchuck Breakout Board https://github.com/Jan--Henrik/hoverboard-breakout
+
 Most robust way for input is to use the ADC and potis. It works well even on 1m unshielded cable. Solder ~100k Ohm resistors between ADC-inputs and gnd directly on the mainboard. Use potis as pullups to 3.3V.
 
 ---

--- a/README.md
+++ b/README.md
@@ -151,13 +151,15 @@ Recommendation: Nunchuck Breakout Board https://github.com/Jan--Henrik/hoverboar
 Most robust way for input is to use the ADC and potis. It works well even on 1m unshielded cable. Solder ~100k Ohm resistors between ADC-inputs and gnd directly on the mainboard. Use potis as pullups to 3.3V.
 
 ---
-## Examples
+## Example variants 
 
-This firmware offers currently 4 variants (selectable in platformio.ino):
+This firmware offers currently these variants (selectable in [platformio.ini](//platformio.ini) and / or config.h):
 - **VARIANT_ADC**: In this variant the motors are controlled by two potentiometers connected to the Left sensor cable (long wired)
-- **VARIANT_USART3**: In this variant the motors are controlled via Serial protocol on USART3 Right sensor cable (short wired). The commands can be sent from an Arduino. Check out the [hoverserial.ino](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/tree/master/02_Arduino/hoverserial) as an example sketch.
-- **HOVERCAR**: In this variant the motors are controlled by two pedals Brake and Throttle. Reverse is engaged by double tapping on the Brake pedal at standstill.
-- **TRANSPOTTER**: This build is for Transpotter which is a hoverboard based transportation system. For more details on how to build it check [here](https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter) and [here](https://hackaday.io/project/161891-transpotter-ng).
+- **VARIANT_USART3**: In this variant the motors are controlled via serial protocol on USART3 right sensor cable (short wired). The commands can be sent from an Arduino. Check out the [hoverserial.ino](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/tree/master/02_Arduino/hoverserial) as an example sketch.
+- **VARIANT_HOVERCAR**: In this variant the motors are controlled by two pedals brake and throttle. Reverse is engaged by double tapping on the brake pedal at standstill.
+- **VARIANT_TRANSPOTTER**: This build is for transpotter which is a hoverboard based transportation system. For more details on how to build it check [here](https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter) and [here](https://hackaday.io/project/161891-transpotter-ng).
+- **VARIANT_NUNCHUCK**: Wii Nunchuck offers one hand control for throttle, braking and steering. This was one of the first input device used for electric armchairs or bottle crates.
+- **VARIANT_PPM**: This is when you want to use a RC remote control with PPM Sum singnal 
 
 Of course the firmware can be further customized for other needs or projects.
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ The main firmware architecture includes:
 - **FOC Algorithm**: implements the FOC strategy
 - **Control Type Manager**: Manages the transition between Commutation, Sinusoidal, and FOC control type
 
-![Firmware architecture](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/blob/master/docs/pictures/FW_architecture.png)
+![Firmware architecture](/docs/pictures/FW_architecture.png)
 
 The FOC algorithm architecture is illustrated in the figure below:
 
-![FOC algorithm](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/blob/master/docs/pictures/FOC_algorithm.png)
+![FOC algorithm](/docs/pictures/FOC_algorithm.png)
 
 In this firmware 3 control types are available:
 - Commutation
 - SIN (Sinusoidal)
 - FOC (Field Oriented Control)
-![Schematic representation of the available control methods](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/blob/master/01_Matlab/02_Figures/control_methods.png)
+![Schematic representation of the available control methods](/01_Matlab/02_Figures/control_methods.png)
 
 
 Demo videos:
@@ -48,13 +48,13 @@ Demo videos:
 
 [►Video: HOVERCAR demo](https://drive.google.com/open?id=18IvRJVdQSsjTg1I0Wedlg19e0FuDjfdS)
 
-![Hoverboard wheel](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/blob/master/docs/pictures/hoverboard_wheel.JPG)
+![Hoverboard wheel](/docs/pictures/hoverboard_wheel.JPG)
 
 
 ---
 ## General Notes
- - The C code for the controller was auto-code generated using [Matlab/Simulink](https://nl.mathworks.com/solutions/embedded-code-generation.html) from a model which I developed from scratch specifically for hoverboard control. For more details regarding the working principle of the controller please consult the [Matlab/Simulink model](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/tree/master/01_Matlab).
- - A [webview](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/tree/master/01_Matlab/BLDC_controller_ert_rtw/html/webview) was created, so Matlab/Simulink installation is not needed, unless you want to regenerate the code. The webview is an html page that can be opened with browsers like: Microsoft Internet Explorer or Microsoft Edge.
+ - The C code for the controller was auto-code generated using [Matlab/Simulink](https://nl.mathworks.com/solutions/embedded-code-generation.html) from a model which I developed from scratch specifically for hoverboard control. For more details regarding the working principle of the controller please consult the [Matlab/Simulink model](/01_Matlab).
+ - A [webview](/01_Matlab/BLDC_controller_ert_rtw/html/webview) was created, so Matlab/Simulink installation is not needed, unless you want to regenerate the code. The webview is an html page that can be opened with browsers like: Microsoft Internet Explorer or Microsoft Edge.
 
 ### Field Weakening / Phase Advance
 
@@ -62,7 +62,7 @@ Demo videos:
  - The Field Weakening is a linear interpolation from 0 to FIELD_WEAK_MAX or PHASE_ADV_MAX (depeding if FOC or SIN is selected, respectively)
  - The Field Weakening starts engaging at FIELD_WEAK_LO and reaches the maximum value at FIELD_WEAK_HI
  - The figure below shows different possible calibrations for Field Weakening / Phase Advance
- ![Field Weakening](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/blob/master/docs/pictures/FieldWeakening.png) 
+ ![Field Weakening](/docs/pictures/FieldWeakening.png) 
  - If you re-calibrate the Field Weakening please take all the safety measures! The motors can spin very fast!
 
 
@@ -72,7 +72,7 @@ Demo videos:
  - For calibrating the fixed-point parameters use the [Fixed-Point Viewer](https://github.com/EmanuelFeru/FixedPointViewer) tool
  - The parameters data Fixed-point types are given in the following table:
 
-![Parameters table](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/blob/master/docs/pictures/paramTable.png)
+![Parameters table](/docs/pictures/paramTable.png)
 
 
 ### Diagnostics
@@ -153,9 +153,9 @@ Most robust way for input is to use the ADC and potis. It works well even on 1m 
 ---
 ## Example variants 
 
-This firmware offers currently these variants (selectable in [platformio.ini](platformio.ini) and / or [config.h](/Inc/config.h)):
+This firmware offers currently these variants (selectable in [platformio.ini](/platformio.ini) and / or [/Inc/config.h](/Inc/config.h)):
 - **VARIANT_ADC**: In this variant the motors are controlled by two potentiometers connected to the Left sensor cable (long wired)
-- **VARIANT_USART3**: In this variant the motors are controlled via serial protocol on USART3 right sensor cable (short wired). The commands can be sent from an Arduino. Check out the [hoverserial.ino](https://github.com/EmanuelFeru/hoverboard-firmware-hack-FOC/tree/master/02_Arduino/hoverserial) as an example sketch.
+- **VARIANT_USART3**: In this variant the motors are controlled via serial protocol on USART3 right sensor cable (short wired). The commands can be sent from an Arduino. Check out the [hoverserial.ino](/02_Arduino/hoverserial) as an example sketch.
 - **VARIANT_HOVERCAR**: In this variant the motors are controlled by two pedals brake and throttle. Reverse is engaged by double tapping on the brake pedal at standstill.
 - **VARIANT_TRANSPOTTER**: This build is for transpotter which is a hoverboard based transportation system. For more details on how to build it check [here](https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter) and [here](https://hackaday.io/project/161891-transpotter-ng).
 - **VARIANT_NUNCHUCK**: Wii Nunchuck offers one hand control for throttle, braking and steering. This was one of the first input device used for electric armchairs or bottle crates.

--- a/Src/main.c
+++ b/Src/main.c
@@ -31,7 +31,7 @@
   #include "hd44780.h"
 #endif
 
-#ifdef TRANSPOTTER
+#ifdef VARIANT_TRANSPOTTER
   #include "eeprom.h"
 #endif
 
@@ -71,7 +71,7 @@ extern volatile adc_buf_t adc_buffer;
   LCD_PCF8574_HandleTypeDef lcd;
 #endif
 extern I2C_HandleTypeDef hi2c2;
-#ifndef TRANSPOTTER
+#ifndef VARIANT_TRANSPOTTER
   extern UART_HandleTypeDef huart2;
   extern UART_HandleTypeDef huart3;
   static UART_HandleTypeDef huart;
@@ -81,7 +81,7 @@ extern I2C_HandleTypeDef hi2c2;
   extern uint8_t LCDerrorFlag;
 #endif
 
-#ifdef TRANSPOTTER
+#ifdef VARIANT_TRANSPOTTER
   uint8_t nunchuck_connected = 0;
   float steering;
   int feedforward;
@@ -142,14 +142,14 @@ uint8_t ctrlModReq    = CTRL_MOD_REQ;   // Final control mode request
 static int        cmd1;                 // normalized input value. -1000 to 1000
 static int        cmd2;                 // normalized input value. -1000 to 1000
 static int16_t    speed;                // local variable for speed. -1000 to 1000
-#ifndef TRANSPOTTER
+#ifndef VARIANT_TRANSPOTTER
   static int16_t  steer;                // local variable for steering. -1000 to 1000
   static int16_t  steerRateFixdt;       // local fixed-point variable for steering rate limiter
   static int16_t  speedRateFixdt;       // local fixed-point variable for speed rate limiter
   static int32_t  steerFixdt;           // local fixed-point variable for steering low-pass filter
   static int32_t  speedFixdt;           // local fixed-point variable for speed low-pass filter
 #endif
-#ifdef HOVERCAR
+#ifdef VARIANT_HOVERCAR
   static MultipleTap MultipleTapBreak;  // define multiple tap functionality for the Break pedal
 #endif
 static int16_t    speedAvg;             // average measured speed
@@ -267,7 +267,7 @@ int main(void) {
 
   HAL_GPIO_WritePin(LED_PORT, LED_PIN, 1);
 
-  #ifdef TRANSPOTTER
+  #ifdef VARIANT_TRANSPOTTER
     int  lastDistance = 0;
     enable = 1;
     uint8_t checkRemote = 0;
@@ -324,7 +324,7 @@ int main(void) {
     LCD_ClearDisplay(&lcd);
     HAL_Delay(5);
     LCD_SetLocation(&lcd, 0, 0);
-    #ifdef TRANSPOTTER
+    #ifdef VARIANT_TRANSPOTTER
       LCD_WriteString(&lcd, "TranspOtter V2.1");
     #else
       LCD_WriteString(&lcd, "Hover V2.0");
@@ -333,7 +333,7 @@ int main(void) {
     LCD_WriteString(&lcd, "Initializing...");
   #endif
 
-  #if defined(TRANSPOTTER) && defined(SUPPORT_LCD)
+  #if defined(VARIANT_TRANSPOTTER) && defined(SUPPORT_LCD)
     LCD_ClearDisplay(&lcd);
     HAL_Delay(5);
     LCD_SetLocation(&lcd, 0, 1);
@@ -363,7 +363,7 @@ int main(void) {
   while(1) {
     HAL_Delay(DELAY_IN_MAIN_LOOP); //delay in ms
 
-    #ifdef TRANSPOTTER
+    #ifdef VARIANT_TRANSPOTTER
       if(HAL_GPIO_ReadPin(BUTTON_PORT, BUTTON_PIN)) {
         enable = 0;
         while(HAL_GPIO_ReadPin(BUTTON_PORT, BUTTON_PIN)) {
@@ -559,7 +559,7 @@ int main(void) {
     } 
     speedAvgAbs   = abs(speedAvg);
 
-    #ifndef TRANSPOTTER
+    #ifndef VARIANT_TRANSPOTTER
       // ####### MOTOR ENABLING: Only if the initial input is very small (for SAFETY) #######
       if (enable == 0 && (!errCode_Left && !errCode_Right) && (cmd1 > -50 && cmd1 < 50) && (cmd2 > -50 && cmd2 < 50)){
         shortBeep(6);                     // make 2 beeps indicating the motor enable
@@ -567,8 +567,8 @@ int main(void) {
         enable = 1;                       // enable motors
       }
 
-      // ####### HOVERCAR #######
-      #ifdef HOVERCAR
+      // ####### VARIANT_HOVERCAR #######
+      #ifdef VARIANT_HOVERCAR
         // Calculate speed Blend, a number between [0, 1] in fixdt(0,16,15)
         uint16_t speedBlend;       
         speedBlend = (uint16_t)(((CLAMP(speedAvgAbs,30,90) - 30) << 15) / 60);     // speedBlend [0,1] is within [30 rpm, 90rpm]
@@ -599,8 +599,8 @@ int main(void) {
       steer = (int16_t)(steerFixdt >> 20);  // convert fixed-point to integer
       speed = (int16_t)(speedFixdt >> 20);  // convert fixed-point to integer    
 
-      // ####### HOVERCAR #######
-      #ifdef HOVERCAR        
+      // ####### VARIANT_HOVERCAR #######
+      #ifdef VARIANT_HOVERCAR        
         if (!MultipleTapBreak.b_multipleTap) {  // Check driving direction
           speed = steer + speed;                // Forward driving          
         } else {
@@ -636,7 +636,7 @@ int main(void) {
     lastSpeedL = speedL;
     lastSpeedR = speedR;
 
-    #ifdef TRANSPOTTER
+    #ifdef VARIANT_TRANSPOTTER
       if (timeout > TIMEOUT) {
         pwml = 0;
         pwmr = 0;
@@ -809,7 +809,7 @@ int main(void) {
   }
 }
 
-#ifdef TRANSPOTTER
+#ifdef VARIANT_TRANSPOTTER
   void saveConfig() {
     HAL_FLASH_Unlock();
     EE_WriteVariable(VirtAddVarTab[0], saveValue);

--- a/Src/main.c
+++ b/Src/main.c
@@ -71,7 +71,8 @@ extern volatile adc_buf_t adc_buffer;
   LCD_PCF8574_HandleTypeDef lcd;
 #endif
 extern I2C_HandleTypeDef hi2c2;
-#ifndef VARIANT_TRANSPOTTER
+#if defined(CONTROL_SERIAL_USART2) || defined(FEEDBACK_SERIAL_USART2) || defined(DEBUG_SERIAL_USART2) \
+ || defined(CONTROL_SERIAL_USART3) || defined(FEEDBACK_SERIAL_USART3) || defined(DEBUG_SERIAL_USART3) 
   extern UART_HandleTypeDef huart2;
   extern UART_HandleTypeDef huart3;
   static UART_HandleTypeDef huart;
@@ -454,7 +455,8 @@ int main(void) {
       cmd1 = CLAMP((ppm_captured_value[0] - INPUT_MID) * 2, INPUT_MIN, INPUT_MAX);
       cmd2 = CLAMP((ppm_captured_value[1] - INPUT_MID) * 2, INPUT_MIN, INPUT_MAX);
       button1 = ppm_captured_value[5] > INPUT_MID;
-      float scale = ppm_captured_value[2] / 1000.0f;
+      button2 = 0;
+      // float scale = ppm_captured_value[2] / 1000.0f;     // not used for now, uncomment if needed
     #endif
 
     #ifdef CONTROL_ADC

--- a/Src/stm32f1xx_it.c
+++ b/Src/stm32f1xx_it.c
@@ -34,6 +34,7 @@
 #include "stm32f1xx_hal.h"
 #include "stm32f1xx.h"
 #include "stm32f1xx_it.h"
+#include "defines.h"
 #include "config.h"
 
 extern DMA_HandleTypeDef hdma_i2c2_rx;

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,9 @@ include_dir = Inc
 src_dir     = Src
 
 ;=================== VARIANT SELECTION ==========================
-default_envs = UNDEFINED            ; 
+;
+; Choose one or all variants get built
+;
 ;default_envs = VARIANT_ADC         ; Variant for control via ADC input
 ;default_envs = VARIANT_USART3      ; Variant for Serial control via USART3 input
 ;default_envs = VARIANT_HOVERCAR    ; Variant for HOVERCAR build

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,10 +6,13 @@ include_dir = Inc
 src_dir     = Src
 
 ;=================== VARIANT SELECTION ==========================
-default_envs = VARIANT_ADC         ; Variant for control via ADC input
+default_envs = UNDEFINED            ; 
+;default_envs = VARIANT_ADC         ; Variant for control via ADC input
 ;default_envs = VARIANT_USART3      ; Variant for Serial control via USART3 input
-;default_envs = HOVERCAR            ; Variant for HOVERCAR build
-;default_envs = TRANSPOTTER         ; Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
+;default_envs = VARIANT_HOVERCAR    ; Variant for HOVERCAR build
+;default_envs = VARIANT_TRANSPOTTER ; Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
+;default_envs = VARIANT_NUNCHUCK    ; Variant for Nunchuck controlled vehicle build
+;default_envs = VARIANT_PPM         ; Variant for RC-Remotes with PPM-Sum signal
 ;================================================================
 
 [env:VARIANT_ADC]
@@ -33,6 +36,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_ADC
+    -D PALTFORMIO
 
 [env:VARIANT_USART3]
 platform        = ststm32
@@ -55,8 +59,9 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_USART3
+    -D PALTFORMIO
 
-[env:HOVERCAR]
+[env:VARIANT_HOVERCAR]
 platform        = ststm32
 framework       = stm32cube
 board           = genericSTM32F103RC
@@ -76,9 +81,10 @@ build_flags =
     -Wl,-lm
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
-    -D HOVERCAR
+    -D VARIANT_HOVERCAR
+    -D PALTFORMIO
 
-[env:TRANSPOTTER]
+[env:VARIANT_TRANSPOTTER]
 platform        = ststm32
 framework       = stm32cube
 board           = genericSTM32F103RC
@@ -94,4 +100,43 @@ build_flags =
     -Wl,-lm
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
-    -D TRANSPOTTER
+    -D VARIANT_TRANSPOTTER
+    -D PALTFORMIO
+
+[env:VARIANT_NUNCHUCK]
+platform        = ststm32
+framework       = stm32cube
+board           = genericSTM32F103RC
+debug_tool      = stlink
+upload_protocol = stlink
+
+build_flags =
+    -I${PROJECT_DIR}/inc/
+    -DUSE_HAL_DRIVER
+    -DSTM32F103xE
+    -Wl,-T./STM32F103RCTx_FLASH.ld
+    -Wl,-lc
+    -Wl,-lm
+    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+#    -Wl,-lnosys
+    -D VARIANT_NUNCHUCK
+    -D PALTFORMIO
+
+[env:VARIANT_PPM]
+platform        = ststm32
+framework       = stm32cube
+board           = genericSTM32F103RC
+debug_tool      = stlink
+upload_protocol = stlink
+
+build_flags =
+    -I${PROJECT_DIR}/inc/
+    -DUSE_HAL_DRIVER
+    -DSTM32F103xE
+    -Wl,-T./STM32F103RCTx_FLASH.ld
+    -Wl,-lc
+    -Wl,-lm
+    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+#    -Wl,-lnosys
+    -D VARIANT_PPM
+    -D PALTFORMIO

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,10 +11,12 @@ src_dir     = Src
 ;
 ;default_envs = VARIANT_ADC         ; Variant for control via ADC input
 ;default_envs = VARIANT_USART3      ; Variant for Serial control via USART3 input
-;default_envs = VARIANT_HOVERCAR    ; Variant for HOVERCAR build
-;default_envs = VARIANT_TRANSPOTTER ; Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
 ;default_envs = VARIANT_NUNCHUCK    ; Variant for Nunchuck controlled vehicle build
 ;default_envs = VARIANT_PPM         ; Variant for RC-Remotes with PPM-Sum signal
+;default_envs = VARIANT_HOVERCAR    ; Variant for HOVERCAR build
+;default_envs = VARIANT_TRANSPOTTER ; Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
+;================================================================
+
 ;================================================================
 
 [env:VARIANT_ADC]
@@ -40,6 +42,8 @@ build_flags =
     -D VARIANT_ADC
     -D PALTFORMIO
 
+;================================================================
+
 [env:VARIANT_USART3]
 platform        = ststm32
 framework       = stm32cube
@@ -62,6 +66,50 @@ build_flags =
 #    -Wl,-lnosys
     -D VARIANT_USART3
     -D PALTFORMIO
+
+;================================================================
+
+[env:VARIANT_NUNCHUCK]
+platform        = ststm32
+framework       = stm32cube
+board           = genericSTM32F103RC
+debug_tool      = stlink
+upload_protocol = stlink
+
+build_flags =
+    -I${PROJECT_DIR}/inc/
+    -DUSE_HAL_DRIVER
+    -DSTM32F103xE
+    -Wl,-T./STM32F103RCTx_FLASH.ld
+    -Wl,-lc
+    -Wl,-lm
+    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+#    -Wl,-lnosys
+    -D VARIANT_NUNCHUCK
+    -D PALTFORMIO
+
+;================================================================
+
+[env:VARIANT_PPM]
+platform        = ststm32
+framework       = stm32cube
+board           = genericSTM32F103RC
+debug_tool      = stlink
+upload_protocol = stlink
+
+build_flags =
+    -I${PROJECT_DIR}/inc/
+    -DUSE_HAL_DRIVER
+    -DSTM32F103xE
+    -Wl,-T./STM32F103RCTx_FLASH.ld
+    -Wl,-lc
+    -Wl,-lm
+    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+#    -Wl,-lnosys
+    -D VARIANT_PPM
+    -D PALTFORMIO
+
+;================================================================
 
 [env:VARIANT_HOVERCAR]
 platform        = ststm32
@@ -86,6 +134,8 @@ build_flags =
     -D VARIANT_HOVERCAR
     -D PALTFORMIO
 
+;================================================================
+
 [env:VARIANT_TRANSPOTTER]
 platform        = ststm32
 framework       = stm32cube
@@ -104,41 +154,5 @@ build_flags =
 #    -Wl,-lnosys
     -D VARIANT_TRANSPOTTER
     -D PALTFORMIO
-
-[env:VARIANT_NUNCHUCK]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -I${PROJECT_DIR}/inc/
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -Wl,-T./STM32F103RCTx_FLASH.ld
-    -Wl,-lc
-    -Wl,-lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-#    -Wl,-lnosys
-    -D VARIANT_NUNCHUCK
-    -D PALTFORMIO
-
-[env:VARIANT_PPM]
-platform        = ststm32
-framework       = stm32cube
-board           = genericSTM32F103RC
-debug_tool      = stlink
-upload_protocol = stlink
-
-build_flags =
-    -I${PROJECT_DIR}/inc/
-    -DUSE_HAL_DRIVER
-    -DSTM32F103xE
-    -Wl,-T./STM32F103RCTx_FLASH.ld
-    -Wl,-lc
-    -Wl,-lm
-    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
-#    -Wl,-lnosys
-    -D VARIANT_PPM
-    -D PALTFORMIO
+    
+;================================================================


### PR DESCRIPTION
- removed default / fallback variant; you are forced to define the variant of your choice now or build will stop with an error
- added condition in config.h to either take setting from platform.ini or config.h
- homogenized default_envs naming; all variants now have VARIANT_ as prefix
- added nunchuck variant in platform.ini and config.h
- added PPM variant in platform.ini and config.h
- README: added jan's nunchuck breakout board repo

Changes due to travis
"make (gcc-arm-none-eabi-7)" and "make (gcc-arm-none-eabi-5)" jobs will build VARIANT_ADC
platformio job will build all variants from plattform.ini 

- platform.ini: removed default_envs UNDEFINED, so travis won't stop and build all variants instead
- .tavis.yml added env: VARIANT=VARIANT_ADC for make builds
- Makefile: added VARIANT environment variable handling
