### PR TITLE
Add FLYSKY IBUS protocol for RC remotes

### DIFF
--- a/Inc/config.h
+++ b/Inc/config.h
@@ -10,6 +10,7 @@
   //#define VARIANT_USART3      // Variant for Serial control via USART3 input
   //#define VARIANT_NUNCHUCK    // Variant for Nunchuck controlled vehicle build
   //#define VARIANT_PPM         // Variant for RC-Remote with PPM-Sum Signal
+  //#define VARIANT_IBUS        // Variant for RC-Remotes with FLYSKY IBUS
   //#define VARIANT_HOVERCAR    // Variant for HOVERCAR build
   //#define VARIANT_TRANSPOTTER // Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
 #endif
@@ -61,7 +62,7 @@
  * Then you can verify voltage on value 6 (to get calibrated voltage multiplied by 100).
  */
 #define BAT_FILT_COEF           655       // battery voltage filter coefficient in fixed-point. coef_fixedPoint = coef_floatingPoint * 2^16. In this case 655 = 0.01 * 2^16
-#define BAT_CALIB_REAL_VOLTAGE  3970      // input voltage measured by multimeter (multiplied by 100). In this case 43.00 V * 100 = 4300
+#define BAT_CALIB_REAL_VOLTAGE  3970      // input voltage measured by multimeter (multiplied by 100). For example 43.00 V * 100 = 4300
 #define BAT_CALIB_ADC           1492      // adc-value measured by mainboard (value nr 5 on UART debug output)
 
 #define BAT_CELLS               10        // battery number of cells. Normal Hoverboard battery: 10s
@@ -133,18 +134,18 @@
   // #define DEBUG_SERIAL_USART3                        // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
 #endif
 
-#ifdef VARIANT_IBUS
-  // ###### CONTROL VIA RC REMOTE WITH FLYSKY IBUS PROTOCOL ######
-  // left sensor board cable. Channel 1: steering, Channel 2: speed.
-  #define CONTROL_IBUS                 // use IBUS as input
-  #define IBUS_NUM_CHANNELS 14         // total number of IBUS channels to receive, even if they are not used.
-  #define IBUS_LENGTH 0x20
-  #define IBUS_COMMAND 0x40
+// ###### CONTROL VIA RC REMOTE WITH FLYSKY IBUS PROTOCOL ######
+/* Connected to Left sensor board cable. Channel 1: steering, Channel 2: speed. */
+#ifdef VARIANT_IBUS     
+  #define CONTROL_IBUS                                  // use IBUS as input
+  #define IBUS_NUM_CHANNELS   14                        // total number of IBUS channels to receive, even if they are not used.
+  #define IBUS_LENGTH         0x20
+  #define IBUS_COMMAND        0x40
 
-  #define CONTROL_SERIAL_USART2                      // left sensor board cable, disable if ADC or PPM is used! For Arduino control check the hoverSerial.ino
-  #define FEEDBACK_SERIAL_USART2                     // left sensor board cable, disable if ADC or PPM is used!
   #undef  USART2_BAUD
-  #define USART2_BAUD 115200
+  #define USART2_BAUD         115200
+  #define CONTROL_SERIAL_USART2                         // left sensor board cable, disable if ADC or PPM is used!
+  #define FEEDBACK_SERIAL_USART2                        // left sensor board cable, disable if ADC or PPM is used!
 #endif
 
 
@@ -156,8 +157,8 @@
   #define UART_DMA_CHANNEL DMA1_Channel2
 #endif
 
+// ###### CONTROL VIA RC REMOTE ######
 #ifdef VARIANT_PPM
-  // ###### CONTROL VIA RC REMOTE ######
   // left sensor board cable. Channel 1: steering, Channel 2: speed.
   #define CONTROL_PPM                 // use PPM-Sum as input. disable CONTROL_SERIAL_USART2!
   #define PPM_NUM_CHANNELS 6          // total number of PPM channels to receive, even if they are not used.

--- a/Inc/config.h
+++ b/Inc/config.h
@@ -133,6 +133,21 @@
   // #define DEBUG_SERIAL_USART3                        // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
 #endif
 
+#ifdef VARIANT_IBUS
+  // ###### CONTROL VIA RC REMOTE WITH FLYSKY IBUS PROTOCOL ######
+  // left sensor board cable. Channel 1: steering, Channel 2: speed.
+  #define CONTROL_IBUS                 // use IBUS as input
+  #define IBUS_NUM_CHANNELS 14         // total number of IBUS channels to receive, even if they are not used.
+  #define IBUS_LENGTH 0x20
+  #define IBUS_COMMAND 0x40
+
+  #define CONTROL_SERIAL_USART2                      // left sensor board cable, disable if ADC or PPM is used! For Arduino control check the hoverSerial.ino
+  #define FEEDBACK_SERIAL_USART2                     // left sensor board cable, disable if ADC or PPM is used!
+  #undef  USART2_BAUD
+  #define USART2_BAUD 115200
+#endif
+
+
 #if defined(FEEDBACK_SERIAL_USART2) || defined(DEBUG_SERIAL_USART2)
   #define UART_DMA_CHANNEL DMA1_Channel7
 #endif
@@ -142,11 +157,11 @@
 #endif
 
 #ifdef VARIANT_PPM
-// ###### CONTROL VIA RC REMOTE ######
-// left sensor board cable. Channel 1: steering, Channel 2: speed.
-#define CONTROL_PPM                 // use PPM-Sum as input. disable CONTROL_SERIAL_USART2!
-#define PPM_NUM_CHANNELS 6          // total number of PPM channels to receive, even if they are not used.
-#endif 
+  // ###### CONTROL VIA RC REMOTE ######
+  // left sensor board cable. Channel 1: steering, Channel 2: speed.
+  #define CONTROL_PPM                 // use PPM-Sum as input. disable CONTROL_SERIAL_USART2!
+  #define PPM_NUM_CHANNELS 6          // total number of PPM channels to receive, even if they are not used.
+#endif
 
 // ###### CONTROL VIA TWO POTENTIOMETERS ######
 /* ADC-calibration to cover the full poti-range:
@@ -317,7 +332,7 @@
 
 // ############################### VALIDATE SETTINGS ###############################
 
-#if !defined(VARIANT_ADC) && !defined(VARIANT_USART3) && !defined(VARIANT_HOVERCAR) && !defined(VARIANT_TRANSPOTTER) && !defined(VARIANT_NUNCHUCK) && !defined(VARIANT_PPM)
+#if !defined(VARIANT_ADC) && !defined(VARIANT_USART3) && !defined(VARIANT_HOVERCAR) && !defined(VARIANT_TRANSPOTTER) && !defined(VARIANT_NUNCHUCK) && !defined(VARIANT_PPM)&& !defined(VARIANT_IBUS)
   #error Variant not defined! Please check platformio.ini or Inc/config.h for available variants.
 #endif
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ Most robust way for input is to use the ADC and potis. It works well even on 1m 
 This firmware offers currently these variants (selectable in [platformio.ini](/platformio.ini) and / or [/Inc/config.h](/Inc/config.h)):
 - **VARIANT_ADC**: In this variant the motors are controlled by two potentiometers connected to the Left sensor cable (long wired)
 - **VARIANT_USART3**: In this variant the motors are controlled via serial protocol on USART3 right sensor cable (short wired). The commands can be sent from an Arduino. Check out the [hoverserial.ino](/02_Arduino/hoverserial) as an example sketch.
+- **VARIANT_NUNCHUCK**: Wii Nunchuck offers one hand control for throttle, braking and steering. This was one of the first input device used for electric armchairs or bottle crates.
+- **VARIANT_PPM**: This is when you want to use a RC remote control with PPM Sum signal
+- **VARIANT_IBUS**: This is when you want to use a RC remote control with Flysky IBUS protocol connected to the Left sensor cable.
 - **VARIANT_HOVERCAR**: In this variant the motors are controlled by two pedals brake and throttle. Reverse is engaged by double tapping on the brake pedal at standstill.
 - **VARIANT_TRANSPOTTER**: This build is for transpotter which is a hoverboard based transportation system. For more details on how to build it check [here](https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter) and [here](https://hackaday.io/project/161891-transpotter-ng).
-- **VARIANT_NUNCHUCK**: Wii Nunchuck offers one hand control for throttle, braking and steering. This was one of the first input device used for electric armchairs or bottle crates.
-- **VARIANT_PPM**: This is when you want to use a RC remote control with PPM Sum singnal 
 
 Of course the firmware can be further customized for other needs or projects.
 

--- a/Src/control.c
+++ b/Src/control.c
@@ -112,8 +112,6 @@ void Nunchuck_Read(void) {
   HAL_Delay(3);
   if (HAL_I2C_Master_Receive(&hi2c2,0xA4,(uint8_t*)nunchuck_data, 6, 10) == HAL_OK) {
     timeout = 0;
-  } else {
-    timeout++;
   }
 
 #ifndef TRANSPOTTER

--- a/Src/main.c
+++ b/Src/main.c
@@ -117,7 +117,7 @@ static uint8_t timeoutFlagADC  = 0;  // Timeout Flag for for ADC Protection: 0 =
       uint8_t  checksuml;
       uint8_t  checksumh;    
     } Serialcommand;
-  #elif
+  #else
     typedef struct{
       uint16_t  start; 
       int16_t   steer;
@@ -529,7 +529,7 @@ int main(void) {
         ibus_chksum -= command.channels[i];
       }
       if (command.start == IBUS_LENGTH && command.type == IBUS_COMMAND && ibus_chksum == ( command.checksumh << 8) + command.checksuml ) {
-      #elif
+      #else
       if (command.start == START_FRAME && command.checksum == (uint16_t)(command.start ^ command.steer ^ command.speed)) {
       #endif   
         if (timeoutFlagSerial) {                      // Check for previous timeout flag  
@@ -542,7 +542,7 @@ int main(void) {
           }
           cmd1 = CLAMP((ibus_captured_value[0] - INPUT_MID) * 2, INPUT_MIN, INPUT_MAX);
           cmd2 = CLAMP((ibus_captured_value[1] - INPUT_MID) * 2, INPUT_MIN, INPUT_MAX);
-          #elif
+          #else
           cmd1            = CLAMP((int16_t)command.steer, INPUT_MIN, INPUT_MAX);
           cmd2            = CLAMP((int16_t)command.speed, INPUT_MIN, INPUT_MAX);
           #endif         

--- a/Src/main.c
+++ b/Src/main.c
@@ -538,7 +538,7 @@ int main(void) {
         } else {
           #ifdef CONTROL_IBUS
           for (uint8_t i = 0; i < (IBUS_NUM_CHANNELS * 2); i +=2) {
-            ibus_captured_value[(i/2)] = CLAMP( command.channels[i] + (command.channels[i+1] << 8) - 1000, INPUT_MIN, INPUT_MAX);
+            ibus_captured_value[(i/2)] = CLAMP( command.channels[i] + (command.channels[i+1] << 8) - 1000, 0, INPUT_MAX); // 1000-2000 -> 0-1000
           }
           cmd1 = CLAMP((ibus_captured_value[0] - INPUT_MID) * 2, INPUT_MIN, INPUT_MAX);
           cmd2 = CLAMP((ibus_captured_value[1] - INPUT_MID) * 2, INPUT_MIN, INPUT_MAX);

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,7 +41,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_ADC
-    -D PALTFORMIO
+    -D PLATFORMIO
 
 ;================================================================
 
@@ -66,7 +66,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_USART3
-    -D PALTFORMIO
+    -D PLATFORMIO
 
 ;================================================================
 
@@ -87,7 +87,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_NUNCHUCK
-    -D PALTFORMIO
+    -D PLATFORMIO
 
 ;================================================================
 
@@ -108,7 +108,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_PPM
-    -D PALTFORMIO
+    -D PLATFORMIO
 
 ;================================================================
 
@@ -129,7 +129,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_IBUS
-    -D PALTFORMIO
+    -D PLATFORMIO
 
 ;================================================================
 
@@ -154,7 +154,7 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_HOVERCAR
-    -D PALTFORMIO
+    -D PLATFORMIO
 
 ;================================================================
 
@@ -175,6 +175,6 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_TRANSPOTTER
-    -D PALTFORMIO
+    -D PLATFORMIO
     
 ;================================================================

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ src_dir     = Src
 ;default_envs = VARIANT_USART3      ; Variant for Serial control via USART3 input
 ;default_envs = VARIANT_NUNCHUCK    ; Variant for Nunchuck controlled vehicle build
 ;default_envs = VARIANT_PPM         ; Variant for RC-Remotes with PPM-Sum signal
+;default_envs = VARIANT_IBUS        ; Variant for RC-Remotes with FLYSKY IBUS
 ;default_envs = VARIANT_HOVERCAR    ; Variant for HOVERCAR build
 ;default_envs = VARIANT_TRANSPOTTER ; Variant for TRANSPOTTER build https://github.com/NiklasFauth/hoverboard-firmware-hack/wiki/Build-Instruction:-TranspOtter https://hackaday.io/project/161891-transpotter-ng
 ;================================================================
@@ -107,6 +108,27 @@ build_flags =
     -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
 #    -Wl,-lnosys
     -D VARIANT_PPM
+    -D PALTFORMIO
+
+;================================================================
+
+[env:VARIANT_IBUS]
+platform        = ststm32
+framework       = stm32cube
+board           = genericSTM32F103RC
+debug_tool      = stlink
+upload_protocol = stlink
+
+build_flags =
+    -I${PROJECT_DIR}/inc/
+    -DUSE_HAL_DRIVER
+    -DSTM32F103xE
+    -Wl,-T./STM32F103RCTx_FLASH.ld
+    -Wl,-lc
+    -Wl,-lm
+    -g -ggdb        ; to generate correctly the 'firmware.elf' for STM STUDIO vizualization
+#    -Wl,-lnosys
+    -D VARIANT_IBUS
     -D PALTFORMIO
 
 ;================================================================


### PR DESCRIPTION
I added FLYSKY IBUS protocol for RC remotes.
It is similar to USART CONTROL but with following structure:
- PROTOCOL LENGTH = 0X20
- PROTOCOL COMMAND = 0X40
- 14 CHANNELS ( low byte high byte ) 
- CHECKSUM low byte
- CHECKSUM high byte

It also requires 115200 baud
